### PR TITLE
Add operator=() to UUID

### DIFF
--- a/ble/UUID.h
+++ b/ble/UUID.h
@@ -167,6 +167,13 @@ public:
         memcpy(baseUUID, source.baseUUID, LENGTH_OF_LONG_UUID);
     }
 
+    const UUID& operator=(const UUID &source) {
+        type      = source.type;
+        shortUUID = source.shortUUID;
+        memcpy(baseUUID, source.baseUUID, LENGTH_OF_LONG_UUID);
+        return *this;
+    }
+
     UUID(void) : type(UUID_TYPE_SHORT), shortUUID(BLE_UUID_UNKNOWN) {
         /* empty */
     }


### PR DESCRIPTION
Add operator=() to UUID to cure the following compilation warning:

warning: implicitly-declared 'UUID& UUID::operator=(const UUID&)' is deprecated [-Wdeprecated-copy]
 note: because 'UUID' has user-provided 'UUID::UUID(const UUID&)'

This is a reasonable warning because if it has been considered necessary to define a copy constructor (as is the case for UUID) then it is most likely that an operator=() is also required.